### PR TITLE
Dialog directives: Intent should be nullable in create() method

### DIFF
--- a/src/Intent/Intent.php
+++ b/src/Intent/Intent.php
@@ -55,17 +55,14 @@ class Intent implements \JsonSerializable
         $data = [];
 
         $data['name'] = $this->name;
-        if (null !== $this->confirmationStatus)
-        {
+        if (null !== $this->confirmationStatus) {
             $data['confirmationStatus'] = $this->confirmationStatus;
         }
 
-        if (!empty($this->slots))
-        {
+        if (!empty($this->slots)) {
             $data['slots'] = [];
 
-            foreach ($this->slots as $slot)
-            {
+            foreach ($this->slots as $slot) {
                 $data['slots'][$slot->name] = $slot->jsonSerialize();
             }
         }
@@ -79,10 +76,8 @@ class Intent implements \JsonSerializable
      */
     public function getSlotByName($name)
     {
-        foreach ($this->slots as $slot)
-        {
-            if ($slot->name === $name)
-            {
+        foreach ($this->slots as $slot) {
+            if ($slot->name === $name) {
                 return $slot;
             }
         }

--- a/src/Intent/Intent.php
+++ b/src/Intent/Intent.php
@@ -72,4 +72,20 @@ class Intent implements \JsonSerializable
 
         return $data;
     }
+
+    /**
+     * @param $name
+     * @return null|Slot
+     */
+    public function getSlotByName($name)
+    {
+        foreach ($this->slots as $slot)
+        {
+            if ($slot->name === $name)
+            {
+                return $slot;
+            }
+        }
+        return null;
+    }
 }

--- a/src/Intent/Intent.php
+++ b/src/Intent/Intent.php
@@ -5,7 +5,7 @@ namespace MaxBeckers\AmazonAlexa\Intent;
 /**
  * @author Maximilian Beckers <beckers.maximilian@gmail.com>
  */
-class Intent
+class Intent implements \JsonSerializable
 {
     const STATUS_NONE      = 'NONE';
     const STATUS_CONFIRMED = 'CONFIRMED';
@@ -45,5 +45,31 @@ class Intent
         }
 
         return $intent;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        $data = [];
+
+        $data['name'] = $this->name;
+        if (null !== $this->confirmationStatus)
+        {
+            $data['confirmationStatus'] = $this->confirmationStatus;
+        }
+
+        if (!empty($this->slots))
+        {
+            $data['slots'] = [];
+
+            foreach ($this->slots as $slot)
+            {
+                $data['slots'][$slot->name] = $slot->jsonSerialize();
+            }
+        }
+
+        return $data;
     }
 }

--- a/src/Intent/Resolution.php
+++ b/src/Intent/Resolution.php
@@ -51,19 +51,15 @@ class Resolution implements \JsonSerializable
     public function jsonSerialize()
     {
         $data = [];
-        if ($this->authority)
-        {
+        if ($this->authority) {
             $data['authority'] = $this->authority;
         }
-        if ($this->status)
-        {
+        if ($this->status) {
             $data['status'] = $this->status;
         }
-        if (!empty($this->values))
-        {
+        if (!empty($this->values)) {
             $data['values'] = [];
-            foreach ($this->values as $value)
-            {
+            foreach ($this->values as $value) {
                 $data['values'][] = [
                     "value" => $value
                 ];

--- a/src/Intent/Resolution.php
+++ b/src/Intent/Resolution.php
@@ -5,7 +5,7 @@ namespace MaxBeckers\AmazonAlexa\Intent;
 /**
  * @author Maximilian Beckers <beckers.maximilian@gmail.com>
  */
-class Resolution
+class Resolution implements \JsonSerializable
 {
     /**
      * @var string|null
@@ -20,7 +20,7 @@ class Resolution
     /**
      * @var IntentStatus|null
      */
-    public $confirmationStatus;
+    public $status;
 
     /**
      * @var IntentValue[]
@@ -48,5 +48,32 @@ class Resolution
         }
 
         return $resolution;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        $data = [];
+        if ($this->authority)
+        {
+            $data['authority'] = $this->authority;
+        }
+        if ($this->status)
+        {
+            $data['status'] = $this->status;
+        }
+        if (!empty($this->values))
+        {
+            $data['values'] = [];
+            foreach ($this->values as $value)
+            {
+                $data['values'][] = [
+                    "value" => $value
+                ];
+            }
+        }
+        return $data;
     }
 }

--- a/src/Intent/Resolution.php
+++ b/src/Intent/Resolution.php
@@ -13,11 +13,6 @@ class Resolution implements \JsonSerializable
     public $authority;
 
     /**
-     * @var string|null
-     */
-    public $value;
-
-    /**
      * @var IntentStatus|null
      */
     public $status;

--- a/src/Intent/Slot.php
+++ b/src/Intent/Slot.php
@@ -62,11 +62,9 @@ class Slot implements \JsonSerializable
         if (null !== $this->confirmationStatus) {
             $data['confirmationStatus'] = $this->confirmationStatus;
         }
-        if (!empty($this->resolutions))
-        {
+        if (!empty($this->resolutions)) {
             $data['resolutions']['resolutionsPerAuthority'] = [];
-            foreach ($this->resolutions as $resolution)
-            {
+            foreach ($this->resolutions as $resolution) {
                 $data['resolutions']['resolutionsPerAuthority'][] = $resolution->jsonSerialize();
             }
         }
@@ -78,11 +76,9 @@ class Slot implements \JsonSerializable
      */
     public function getFirstResolutionIntentValue()
     {
-        if ($this->resolutions[0])
-        {
+        if (isset($this->resolutions[0])) {
             $resolution = $this->resolutions[0];
-            if ($resolution->values[0])
-            {
+            if (isset($resolution->values[0])) {
                 return $resolution->values[0];
             }
         }

--- a/src/Intent/Slot.php
+++ b/src/Intent/Slot.php
@@ -72,4 +72,20 @@ class Slot implements \JsonSerializable
         }
         return $data;
     }
+
+    /**
+     * @return IntentValue|null
+     */
+    public function getFirstResolutionIntentValue()
+    {
+        if ($this->resolutions[0])
+        {
+            $resolution = $this->resolutions[0];
+            if ($resolution->values[0])
+            {
+                return $resolution->values[0];
+            }
+        }
+        return null;
+    }
 }

--- a/src/Intent/Slot.php
+++ b/src/Intent/Slot.php
@@ -5,7 +5,7 @@ namespace MaxBeckers\AmazonAlexa\Intent;
 /**
  * @author Maximilian Beckers <beckers.maximilian@gmail.com>
  */
-class Slot
+class Slot implements \JsonSerializable
 {
     /**
      * @var string
@@ -47,5 +47,29 @@ class Slot
         }
 
         return $slot;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        $data = [];
+        $data['name'] = $this->name;
+        if (null !== $this->value) {
+            $data['value'] = $this->value;
+        }
+        if (null !== $this->confirmationStatus) {
+            $data['confirmationStatus'] = $this->confirmationStatus;
+        }
+        if (!empty($this->resolutions))
+        {
+            $data['resolutions']['resolutionsPerAuthority'] = [];
+            foreach ($this->resolutions as $resolution)
+            {
+                $data['resolutions']['resolutionsPerAuthority'][] = $resolution->jsonSerialize();
+            }
+        }
+        return $data;
     }
 }

--- a/src/Response/Directives/Dialog/ConfirmIntentDirective.php
+++ b/src/Response/Directives/Dialog/ConfirmIntentDirective.php
@@ -18,11 +18,11 @@ class ConfirmIntentDirective extends Directive
     public $updatedIntent;
 
     /**
-     * @param Intent $intent
+     * @param Intent|null $intent
      *
      * @return ConfirmIntentDirective
      */
-    public static function create(Intent $intent): ConfirmIntentDirective
+    public static function create(Intent $intent = null): ConfirmIntentDirective
     {
         $confirmIntentDirective = new self();
 

--- a/src/Response/Directives/Dialog/ConfirmSlotDirective.php
+++ b/src/Response/Directives/Dialog/ConfirmSlotDirective.php
@@ -24,11 +24,11 @@ class ConfirmSlotDirective extends Directive
 
     /**
      * @param string $slotToConfirm
-     * @param Intent $intent
+     * @param Intent|null $intent
      *
      * @return ConfirmSlotDirective
      */
-    public static function create(string $slotToConfirm, Intent $intent): ConfirmSlotDirective
+    public static function create(string $slotToConfirm, Intent $intent = null): ConfirmSlotDirective
     {
         $confirmSlotDirective = new self();
 

--- a/src/Response/Directives/Dialog/DelegateDirective.php
+++ b/src/Response/Directives/Dialog/DelegateDirective.php
@@ -18,11 +18,11 @@ class DelegateDirective extends Directive
     public $updatedIntent;
 
     /**
-     * @param Intent $intent
+     * @param Intent|null $intent
      *
      * @return DelegateDirective
      */
-    public static function create(Intent $intent): DelegateDirective
+    public static function create(Intent $intent = null): DelegateDirective
     {
         $delegateDirective = new self();
 

--- a/src/Response/Directives/Dialog/ElicitSlotDirective.php
+++ b/src/Response/Directives/Dialog/ElicitSlotDirective.php
@@ -24,11 +24,11 @@ class ElicitSlotDirective extends Directive
 
     /**
      * @param string $slotToElicit
-     * @param Intent $intent
+     * @param Intent|null $intent
      *
      * @return ElicitSlotDirective
      */
-    public static function create(string $slotToElicit, Intent $intent): ElicitSlotDirective
+    public static function create(string $slotToElicit, Intent $intent = null): ElicitSlotDirective
     {
         $elicitSlotDirective = new self();
 

--- a/test/Tests/Intent/Data/intent_resolution.json
+++ b/test/Tests/Intent/Data/intent_resolution.json
@@ -1,0 +1,27 @@
+{
+  "name": "GetMediaIntent",
+  "slots": {
+    "MediaType": {
+      "name": "MediaType",
+      "value": "track",
+      "resolutions": {
+        "resolutionsPerAuthority": [
+          {
+            "authority": "amzn1.er-authority.echo-sdk.<skill_id>.MEDIA_TYPE",
+            "status": {
+              "code": "ER_SUCCESS_MATCH"
+            },
+            "values": [
+              {
+                "value": {
+                  "name": "song",
+                  "id": "SONG"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/Tests/Intent/Data/intent_without_resolutions.json
+++ b/test/Tests/Intent/Data/intent_without_resolutions.json
@@ -1,0 +1,14 @@
+{
+  "name": "Start",
+  "confirmationStatus": "NONE",
+  "slots": {
+    "Age": {
+      "name": "Age",
+      "confirmationStatus": "NONE"
+    },
+    "Gender": {
+      "name": "Gender",
+      "confirmationStatus": "NONE"
+    }
+  }
+}

--- a/test/Tests/Intent/Data/slot_media_type.json
+++ b/test/Tests/Intent/Data/slot_media_type.json
@@ -1,0 +1,22 @@
+{
+  "name": "MediaType",
+  "value": "track",
+  "resolutions": {
+    "resolutionsPerAuthority": [
+      {
+        "authority": "amzn1.er-authority.echo-sdk.<skill_id>.MEDIA_TYPE",
+        "status": {
+          "code": "ER_SUCCESS_MATCH"
+        },
+        "values": [
+          {
+            "value": {
+              "name": "song",
+              "id": "SONG"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/Tests/Intent/Data/slot_no_resolution.json
+++ b/test/Tests/Intent/Data/slot_no_resolution.json
@@ -1,0 +1,4 @@
+{
+    "name": "Age",
+    "confirmationStatus": "NONE"
+}

--- a/test/Tests/Intent/Data/slot_to_city.json
+++ b/test/Tests/Intent/Data/slot_to_city.json
@@ -1,0 +1,23 @@
+{
+  "name": "toCity",
+  "value": "the windy city",
+  "resolutions": {
+    "resolutionsPerAuthority": [
+      {
+        "authority": "amzn1.er-authority.echo-sdk.<skill_id>.AMAZON.US_CITY",
+        "status": {
+          "code": "ER_SUCCESS_MATCH"
+        },
+        "values": [
+          {
+            "value": {
+              "name": "chicago",
+              "id": "ORD"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "confirmationStatus": "NONE"
+}

--- a/test/Tests/Intent/IntentTest.php
+++ b/test/Tests/Intent/IntentTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use MaxBeckers\AmazonAlexa\Intent\Slot;
+use \MaxBeckers\AmazonAlexa\Intent\Intent;
+
+/**
+ * @author Fabian Graßl <fabian.grassl@db-n.com>
+ */
+class IntentTest extends TestCase
+{
+    public function testSlotMediaType()
+    {
+        $json = file_get_contents(__DIR__.'/Data/slot_media_type.json');
+        $slot = Slot::fromAmazonRequest("MediaType", json_decode($json, true));
+        $this->assertJsonStringEqualsJsonString($json, json_encode($slot));
+    }
+
+    public function testSlottoCity()
+    {
+        $json = file_get_contents(__DIR__.'/Data/slot_to_city.json');
+        $slot = Slot::fromAmazonRequest("toCity", json_decode($json, true));
+        $this->assertJsonStringEqualsJsonString($json, json_encode($slot));
+    }
+
+    public function testWithoutResolutions()
+    {
+        $json = file_get_contents(__DIR__.'/Data/intent_without_resolutions.json');
+        $intent = Intent::fromAmazonRequest(json_decode($json, true));
+        $this->assertJsonStringEqualsJsonString($json, json_encode($intent));
+    }
+
+    public function testWithResolutions()
+    {
+        $json = file_get_contents(__DIR__.'/Data/intent_resolution.json');
+        $intent = Intent::fromAmazonRequest(json_decode($json, true));
+        $this->assertJsonStringEqualsJsonString($json, json_encode($intent));
+    }
+}

--- a/test/Tests/Intent/IntentTest.php
+++ b/test/Tests/Intent/IntentTest.php
@@ -1,28 +1,18 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-use MaxBeckers\AmazonAlexa\Intent\Slot;
 use \MaxBeckers\AmazonAlexa\Intent\Intent;
+use \MaxBeckers\AmazonAlexa\Intent\Slot;
 
 /**
  * @author Fabian Graßl <fabian.grassl@db-n.com>
  */
 class IntentTest extends TestCase
 {
-    public function testSlotMediaType()
-    {
-        $json = file_get_contents(__DIR__.'/Data/slot_media_type.json');
-        $slot = Slot::fromAmazonRequest("MediaType", json_decode($json, true));
-        $this->assertJsonStringEqualsJsonString($json, json_encode($slot));
-    }
-
-    public function testSlottoCity()
-    {
-        $json = file_get_contents(__DIR__.'/Data/slot_to_city.json');
-        $slot = Slot::fromAmazonRequest("toCity", json_decode($json, true));
-        $this->assertJsonStringEqualsJsonString($json, json_encode($slot));
-    }
-
+    /**
+     * @covers Intent::fromAmazonRequest()
+     * @covers Intent::jsonSerialize()
+     */
     public function testWithoutResolutions()
     {
         $json = file_get_contents(__DIR__.'/Data/intent_without_resolutions.json');
@@ -30,10 +20,31 @@ class IntentTest extends TestCase
         $this->assertJsonStringEqualsJsonString($json, json_encode($intent));
     }
 
+    /**
+     * @covers Intent::fromAmazonRequest()
+     * @covers Intent::jsonSerialize()
+     */
     public function testWithResolutions()
     {
         $json = file_get_contents(__DIR__.'/Data/intent_resolution.json');
         $intent = Intent::fromAmazonRequest(json_decode($json, true));
         $this->assertJsonStringEqualsJsonString($json, json_encode($intent));
+    }
+
+    /**
+     * @covers Intent::getSlotByName()
+     */
+    public function testGetResolutionByName()
+    {
+        $json = file_get_contents(__DIR__.'/Data/intent_without_resolutions.json');
+        $intent = Intent::fromAmazonRequest(json_decode($json, true));
+        $slot = $intent->getSlotByName("Age");
+        $this->assertInstanceOf(Slot::class, $slot);
+        $this->assertEquals("Age", $slot->name);
+        $slot = $intent->getSlotByName("age");
+        $this->assertNull($slot);
+        $slot = $intent->getSlotByName("Gender");
+        $this->assertInstanceOf(Slot::class, $slot);
+        $this->assertEquals("Gender", $slot->name);
     }
 }

--- a/test/Tests/Intent/SlotTest.php
+++ b/test/Tests/Intent/SlotTest.php
@@ -42,5 +42,8 @@ class SlotTest extends TestCase
         $this->assertInstanceOf(IntentValue::class, $intentValue);
         $this->assertEquals("chicago", $intentValue->name);
         $this->assertEquals("ORD", $intentValue->id);
+        $json = file_get_contents(__DIR__.'/Data/slot_no_resolution.json');
+        $slot = Slot::fromAmazonRequest("toCity", json_decode($json, true));
+        $this->assertNull($slot->getFirstResolutionIntentValue());
     }
 }

--- a/test/Tests/Intent/SlotTest.php
+++ b/test/Tests/Intent/SlotTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use MaxBeckers\AmazonAlexa\Intent\Slot;
+
+/**
+ * @author Fabian Graßl <fabian.grassl@db-n.com>
+ */
+class SlotTest extends TestCase
+{
+    /**
+     * @covers Slot::fromAmazonRequest()
+     * @covers Slot::jsonSerialize()
+     */
+    public function testSlotMediaType()
+    {
+        $json = file_get_contents(__DIR__.'/Data/slot_media_type.json');
+        $slot = Slot::fromAmazonRequest("MediaType", json_decode($json, true));
+        $this->assertJsonStringEqualsJsonString($json, json_encode($slot));
+    }
+
+    /**
+     * @covers Slot::fromAmazonRequest()
+     * @covers Slot::jsonSerialize()
+     */
+    public function testSlottoCity()
+    {
+        $json = file_get_contents(__DIR__.'/Data/slot_to_city.json');
+        $slot = Slot::fromAmazonRequest("toCity", json_decode($json, true));
+        $this->assertJsonStringEqualsJsonString($json, json_encode($slot));
+    }
+}

--- a/test/Tests/Intent/SlotTest.php
+++ b/test/Tests/Intent/SlotTest.php
@@ -2,6 +2,7 @@
 
 use PHPUnit\Framework\TestCase;
 use MaxBeckers\AmazonAlexa\Intent\Slot;
+use MaxBeckers\AmazonAlexa\Intent\IntentValue;
 
 /**
  * @author Fabian Graßl <fabian.grassl@db-n.com>
@@ -28,5 +29,18 @@ class SlotTest extends TestCase
         $json = file_get_contents(__DIR__.'/Data/slot_to_city.json');
         $slot = Slot::fromAmazonRequest("toCity", json_decode($json, true));
         $this->assertJsonStringEqualsJsonString($json, json_encode($slot));
+    }
+
+    /**
+     * @covers Slot::getFirstResolutionIntentValue()
+     */
+    public function testGetFirstResolutionIntentValue()
+    {
+        $json = file_get_contents(__DIR__.'/Data/slot_to_city.json');
+        $slot = Slot::fromAmazonRequest("toCity", json_decode($json, true));
+        $intentValue = $slot->getFirstResolutionIntentValue();
+        $this->assertInstanceOf(IntentValue::class, $intentValue);
+        $this->assertEquals("chicago", $intentValue->name);
+        $this->assertEquals("ORD", $intentValue->id);
     }
 }


### PR DESCRIPTION
The updated Intent is not required for all Dialog directives according to the Amazon documentation. It should therefore be nullable in the create() method.

See Amazon documentation:
https://developer.amazon.com/de/docs/custom-skills/dialog-interface-reference.html#directives

I additionally fixed the JSON serialization of the Intent object (Needed for DialogDirectives with "updatedIntent"). The output JSON now matches the input JSON.