### PR TITLE
 create() Methods for VideoApp

### DIFF
--- a/src/Response/Directives/VideoApp/Metadata.php
+++ b/src/Response/Directives/VideoApp/Metadata.php
@@ -31,4 +31,20 @@ class Metadata
 
         return $metadata;
     }
+
+
+    /**
+     * @param string|null $title
+     * @param string|null $subtitle
+     * @return Metadata
+     */
+    public static function create(string $title = null, string $subtitle = null): Metadata
+    {
+        $metadata = new self();
+
+        $metadata->title    = $title;
+        $metadata->subtitle = $subtitle;
+
+        return $metadata;
+    }
 }

--- a/src/Response/Directives/VideoApp/Metadata.php
+++ b/src/Response/Directives/VideoApp/Metadata.php
@@ -32,7 +32,6 @@ class Metadata
         return $metadata;
     }
 
-
     /**
      * @param string|null $title
      * @param string|null $subtitle

--- a/src/Response/Directives/VideoApp/VideoItem.php
+++ b/src/Response/Directives/VideoApp/VideoItem.php
@@ -31,4 +31,19 @@ class VideoItem
 
         return $request;
     }
+
+    /**
+     * @param string $source
+     * @param Metadata|null $metadata
+     * @return VideoItem
+     */
+    public static function create(string $source, Metadata $metadata = null): VideoItem
+    {
+        $videoItem = new self();
+
+        $videoItem->source   = $source;
+        $videoItem->metadata = $metadata;
+
+        return $videoItem;
+    }
 }

--- a/src/Response/Directives/VideoApp/VideoLaunchDirective.php
+++ b/src/Response/Directives/VideoApp/VideoLaunchDirective.php
@@ -25,7 +25,7 @@ class VideoLaunchDirective extends Directive
     {
         $videoLaunchDirective = new self();
 
-        $videoLaunchDirective->type          = self::TYPE;
+        $videoLaunchDirective->type      = self::TYPE;
         $videoLaunchDirective->videoItem = $videoItem;
 
         return $videoLaunchDirective;

--- a/src/Response/Directives/VideoApp/VideoLaunchDirective.php
+++ b/src/Response/Directives/VideoApp/VideoLaunchDirective.php
@@ -16,4 +16,18 @@ class VideoLaunchDirective extends Directive
      * @var VideoItem|null
      */
     public $videoItem;
+
+    /**
+     * @param VideoItem|null $videoItem
+     * @return VideoLaunchDirective
+     */
+    public static function create(VideoItem $videoItem = null): VideoLaunchDirective
+    {
+        $videoLaunchDirective = new self();
+
+        $videoLaunchDirective->type          = self::TYPE;
+        $videoLaunchDirective->videoItem = $videoItem;
+
+        return $videoLaunchDirective;
+    }
 }

--- a/src/Response/ResponseBody.php
+++ b/src/Response/ResponseBody.php
@@ -7,7 +7,7 @@ use MaxBeckers\AmazonAlexa\Response\Directives\Directive;
 /**
  * @author Maximilian Beckers <beckers.maximilian@gmail.com>
  */
-class ResponseBody
+class ResponseBody implements \JsonSerializable
 {
     /**
      * @var OutputSpeech|null
@@ -42,5 +42,30 @@ class ResponseBody
     public function addDirective(Directive $directive)
     {
         $this->directives[] = $directive;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize()
+    {
+        $data = [];
+        if (null !== $this->outputSpeech) {
+            $data['outputSpeech'] = $this->outputSpeech;
+        }
+        if (null !== $this->card) {
+            $data['card'] = $this->card;
+        }
+        if (null !== $this->reprompt) {
+            $data['reprompt'] = $this->reprompt;
+        }
+        if (null !== $this->shouldEndSession) {
+            $data['shouldEndSession'] = $this->shouldEndSession;
+        }
+        if (!empty($this->directives)) {
+            $data['directives'] = $this->directives;
+        }
+
+        return $data;
     }
 }

--- a/test/Tests/Response/Directives/VideoAppTest.php
+++ b/test/Tests/Response/Directives/VideoAppTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use \MaxBeckers\AmazonAlexa\Response\Directives\VideoApp\VideoLaunchDirective;
+use \MaxBeckers\AmazonAlexa\Response\Directives\VideoApp\Metadata;
+use \MaxBeckers\AmazonAlexa\Response\Directives\VideoApp\VideoItem;
+
+/**
+ * @author Fabian Graßl <fabian.grassl@db-n.com>
+ */
+class VideoAppTest extends TestCase
+{
+    /**
+     * @covers Metadata::create()
+     */
+    public function testMetadata()
+    {
+        $meta = Metadata::create();
+        $this->assertInstanceOf(Metadata::class, $meta);
+        $this->assertNull($meta->title);
+        $this->assertNull($meta->subtitle);
+
+        $meta = Metadata::create("Test");
+        $this->assertInstanceOf(Metadata::class, $meta);
+        $this->assertEquals("Test", $meta->title);
+        $this->assertNull($meta->subtitle);
+
+        $meta = Metadata::create("Test", "Sub");
+        $this->assertEquals("Sub", $meta->subtitle);
+    }
+
+    /**
+     * @covers VideoItem::create()
+     */
+    public function testVideoItem()
+    {
+        $vi = VideoItem::create("http://example.com/video.mp4");
+        $this->assertInstanceOf(VideoItem::class, $vi);
+        $this->assertEquals("http://example.com/video.mp4", $vi->source);
+        $this->assertNull($vi->metadata);
+
+        $m = Metadata::create();
+        $vi = VideoItem::create("http://example.com/video.mp4", $m);
+        $this->assertEquals($m, $vi->metadata);
+    }
+
+    /**
+     * @covers VideoLaunchDirective::create()
+     */
+    public function testVideoLaunchDirective()
+    {
+        $vc = VideoLaunchDirective::create();
+        $this->assertEquals('VideoApp.Launch', $vc->type);
+        $this->assertNull($vc->videoItem);
+
+        $vi = VideoItem::create("http://example.com/video.mp4");
+        $vc = VideoLaunchDirective::create($vi);
+        $this->assertEquals($vi, $vc->videoItem);
+    }
+}

--- a/test/Tests/Response/ResponseBodyTest.php
+++ b/test/Tests/Response/ResponseBodyTest.php
@@ -6,6 +6,7 @@ use \MaxBeckers\AmazonAlexa\Response\Card;
 use \MaxBeckers\AmazonAlexa\Response\OutputSpeech;
 use \MaxBeckers\AmazonAlexa\Response\Directives\Display\RenderTemplateDirective;
 use \MaxBeckers\AmazonAlexa\Response\Reprompt;
+
 /**
  * @author Fabian Graßl <fabian.grassl@db-n.com>
  */

--- a/test/Tests/Response/ResponseBodyTest.php
+++ b/test/Tests/Response/ResponseBodyTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use \MaxBeckers\AmazonAlexa\Response\ResponseBody;
+use \MaxBeckers\AmazonAlexa\Response\Card;
+use \MaxBeckers\AmazonAlexa\Response\OutputSpeech;
+use \MaxBeckers\AmazonAlexa\Response\Directives\Display\RenderTemplateDirective;
+use \MaxBeckers\AmazonAlexa\Response\Reprompt;
+/**
+ * @author Fabian Graßl <fabian.grassl@db-n.com>
+ */
+class ResponseBodyTest extends TestCase
+{
+    public function testJsonSerialize()
+    {
+        $rb = new ResponseBody();
+        $this->assertEquals([], $rb->jsonSerialize());
+        $rb->shouldEndSession = true;
+        $this->assertEquals(["shouldEndSession" => true], $rb->jsonSerialize());
+        $card = new Card();
+        $rb->card = $card;
+        $os = new OutputSpeech();
+        $rb->outputSpeech = $os;
+        $directive = new RenderTemplateDirective();
+        $rb->addDirective($directive);
+        $reprompt = new Reprompt($rb->outputSpeech);
+        $rb->reprompt = $reprompt;
+        $this->assertEquals([
+            "outputSpeech" => $os,
+            "card" => $card,
+            "reprompt" => $reprompt,
+            "shouldEndSession" => true,
+            "directives" => [$directive]
+        ], $rb->jsonSerialize());
+    }
+}


### PR DESCRIPTION
I have also added a jsonSerialize() method to ResponseBody:
Amazon throws an error if the shouldEndSession flag is set:

> shouldEndSession flag is not allowed with LaunchVideoApp.Launch Directive