### PR TITLE
Fix JSON serializing for empty (sub-)objects

### DIFF
--- a/src/Response/Card.php
+++ b/src/Response/Card.php
@@ -91,7 +91,7 @@ class Card implements \JsonSerializable
      */
     public function jsonSerialize()
     {
-        $data = [];
+        $data = new \ArrayObject();
 
         if (null !== $this->type) {
             $data['type'] = $this->type;

--- a/src/Response/Directives/Display/ImageSource.php
+++ b/src/Response/Directives/Display/ImageSource.php
@@ -58,7 +58,7 @@ class ImageSource implements \JsonSerializable
      */
     public function jsonSerialize()
     {
-        $data = [];
+        $data = new \ArrayObject();
 
         if (null !== $this->url) {
             $data['url'] = $this->url;

--- a/src/Response/ResponseBody.php
+++ b/src/Response/ResponseBody.php
@@ -49,7 +49,8 @@ class ResponseBody implements \JsonSerializable
      */
     public function jsonSerialize()
     {
-        $data = [];
+        $data = new \ArrayObject();
+
         if (null !== $this->outputSpeech) {
             $data['outputSpeech'] = $this->outputSpeech;
         }

--- a/test/Tests/Response/CardTest.php
+++ b/test/Tests/Response/CardTest.php
@@ -15,11 +15,11 @@ class CardTest extends TestCase
         $content = 'content';
 
         $card = Card::createSimple($title, $content);
-        $this->assertSame([
+        $this->assertEquals(new ArrayObject([
             'type'    => Card::TYPE_SIMPLE,
             'title'   => $title,
             'content' => $content,
-        ], $card->jsonSerialize());
+        ]), $card->jsonSerialize());
     }
 
     public function testStandardCardWithoutImage()
@@ -28,11 +28,11 @@ class CardTest extends TestCase
         $text  = 'content';
 
         $card = Card::createStandard($title, $text);
-        $this->assertSame([
+        $this->assertEquals(new ArrayObject([
             'type'  => Card::TYPE_STANDARD,
             'title' => $title,
             'text'  => $text,
-        ], $card->jsonSerialize());
+        ]), $card->jsonSerialize());
     }
 
     public function testStandardCardWithImage()
@@ -42,19 +42,19 @@ class CardTest extends TestCase
         $image  = CardImage::fromUrls('https://www.img.test/small.png', 'https://www.img.test/large.png');
 
         $card = Card::createStandard($title, $text, $image);
-        $this->assertSame([
+        $this->assertEquals(new ArrayObject([
             'type'   => Card::TYPE_STANDARD,
             'title'  => $title,
             'text'   => $text,
             'image'  => $image,
-        ], $card->jsonSerialize());
+        ]), $card->jsonSerialize());
     }
 
     public function testLinkAccount()
     {
         $card = Card::createLinkAccount();
-        $this->assertSame([
+        $this->assertEquals(new ArrayObject([
             'type'  => Card::TYPE_LINK_ACCOUNT,
-        ], $card->jsonSerialize());
+        ]), $card->jsonSerialize());
     }
 }

--- a/test/Tests/Response/Directives/DisplayTest.php
+++ b/test/Tests/Response/Directives/DisplayTest.php
@@ -54,7 +54,7 @@ class DisplayTest extends TestCase
         $this->assertNull($imageSource->size);
         $this->assertNull($imageSource->widthPixels);
         $this->assertNull($imageSource->heightPixels);
-        $this->assertSame(['url' => $imgUrl], $imageSource->jsonSerialize());
+        $this->assertEquals(new ArrayObject(['url' => $imgUrl]), $imageSource->jsonSerialize());
     }
 
     public function testImage()

--- a/test/Tests/Response/ResponseBodyTest.php
+++ b/test/Tests/Response/ResponseBodyTest.php
@@ -15,9 +15,9 @@ class ResponseBodyTest extends TestCase
     public function testJsonSerialize()
     {
         $rb = new ResponseBody();
-        $this->assertSame([], $rb->jsonSerialize());
+        $this->assertEquals(new ArrayObject(), $rb->jsonSerialize());
         $rb->shouldEndSession = true;
-        $this->assertSame(['shouldEndSession' => true], $rb->jsonSerialize());
+        $this->assertEquals(new ArrayObject(['shouldEndSession' => true]), $rb->jsonSerialize());
         $card             = new Card();
         $rb->card         = $card;
         $os               = new OutputSpeech();
@@ -26,12 +26,12 @@ class ResponseBodyTest extends TestCase
         $rb->addDirective($directive);
         $reprompt     = new Reprompt($rb->outputSpeech);
         $rb->reprompt = $reprompt;
-        $this->assertSame([
+        $this->assertEquals(new ArrayObject([
             'outputSpeech'     => $os,
             'card'             => $card,
             'reprompt'         => $reprompt,
             'shouldEndSession' => true,
             'directives'       => [$directive],
-        ], $rb->jsonSerialize());
+        ]), $rb->jsonSerialize());
     }
 }

--- a/test/Tests/Response/ResponseTest.php
+++ b/test/Tests/Response/ResponseTest.php
@@ -1,0 +1,14 @@
+<?php
+
+
+use MaxBeckers\AmazonAlexa\Response\Response;
+use PHPUnit\Framework\TestCase;
+
+class ResponseTest extends TestCase
+{
+    public function testEmptyResponse()
+    {
+        $response = new Response();
+        $this->assertSame('{"version":"1.0","sessionAttributes":[],"response":{}}', json_encode($response));
+    }
+}


### PR DESCRIPTION
`jsonSerialize` returns an associative array that could possibly be empty, which later`json_encode` only as json-array `[]` and not as empty json-object `{}`.

Using a plain `return new Reponse()` to "handle" for example an AudioPlayer Request results in an Exception from Alexa as the json is wrong 
`{"version":"1.0","sessionAttributes":[],"response":[]}` vs `{"version":"1.0","sessionAttributes":[],"response":{}}`