### PR TITLE
Fixed Game Engine RecognizerMatch, Event and Pattern

### DIFF
--- a/src/Response/Directives/GameEngine/Event.php
+++ b/src/Response/Directives/GameEngine/Event.php
@@ -17,9 +17,9 @@ class Event
     public $meets = [];
 
     /**
-     * @var array
+     * @var array|null
      */
-    public $fails = [];
+    public $fails;
 
     /**
      * @var string|null
@@ -44,14 +44,14 @@ class Event
     /**
      * @param array       $meets
      * @param bool        $shouldEndInputHandler
-     * @param array       $fails
+     * @param array|null  $fails
      * @param string|null $reports
      * @param int|null    $maximumInvocations
      * @param int|null    $triggerTimeMilliseconds
      *
      * @return Event
      */
-    public static function create(array $meets, bool $shouldEndInputHandler, array $fails = [], string $reports = null, int $maximumInvocations = null, int $triggerTimeMilliseconds = null): self
+    public static function create(array $meets, bool $shouldEndInputHandler, array $fails = null, string $reports = null, int $maximumInvocations = null, int $triggerTimeMilliseconds = null): self
     {
         $event = new self();
 

--- a/src/Response/Directives/GameEngine/Pattern.php
+++ b/src/Response/Directives/GameEngine/Pattern.php
@@ -27,19 +27,26 @@ class Pattern
     public $action;
 
     /**
+     * @var int|null
+     */
+    public $repeat;
+
+    /**
      * @param string|null $action
-     * @param array       $gadgetIds
-     * @param array       $colors
+     * @param array|null  $gadgetIds
+     * @param array|null  $colors
+     * @param int|null    $repeat
      *
      * @return Pattern
      */
-    public static function create(string $action = null, array $gadgetIds = [], array $colors = []): self
+    public static function create(string $action = null, $gadgetIds = null, $colors = null, $repeat = null): self
     {
         $pattern = new self();
 
         $pattern->action    = $action;
         $pattern->gadgetIds = $gadgetIds;
         $pattern->colors    = $colors;
+        $pattern->repeat    = $repeat;
 
         return $pattern;
     }

--- a/src/Response/Directives/GameEngine/RecognizerMatch.php
+++ b/src/Response/Directives/GameEngine/RecognizerMatch.php
@@ -23,14 +23,14 @@ class RecognizerMatch extends Recognizer
     public $fuzzy;
 
     /**
-     * @var array
+     * @var array|null
      */
-    public $gadgetIds = [];
+    public $gadgetIds;
 
     /**
-     * @var array
+     * @var array|null
      */
-    public $actions = [];
+    public $actions;
 
     /**
      * @var Pattern[]
@@ -38,15 +38,15 @@ class RecognizerMatch extends Recognizer
     public $pattern = [];
 
     /**
-     * @param string    $anchor
-     * @param bool      $fuzzy
-     * @param array     $gadgetIds
-     * @param array     $actions
-     * @param Pattern[] $pattern
+     * @param Pattern[]  $pattern
+     * @param string     $anchor
+     * @param bool       $fuzzy
+     * @param array|null $gadgetIds
+     * @param array|null $actions
      *
      * @return RecognizerMatch
      */
-    public static function create(string $anchor, bool $fuzzy, array $gadgetIds = [], array $actions = [], array $pattern = []): self
+    public static function create(array $pattern, string $anchor = self::ANCHOR_START, bool $fuzzy = false, $gadgetIds = null, $actions = null): self
     {
         $recognizer = new self();
 

--- a/test/Test/Response/Directives/GameEngineTest.php
+++ b/test/Test/Response/Directives/GameEngineTest.php
@@ -21,7 +21,7 @@ class GameEngineTest extends TestCase
         $pattern = Pattern::create(Pattern::ACTION_UP, ['gadgetId1', 'gadgetId2'], ['blue']);
 
         $recognizers = [
-            'test_match'     => RecognizerMatch::create(RecognizerMatch::ANCHOR_START, false, ['gadgetId1', 'gadgetId2'], [Pattern::ACTION_UP], [$pattern]),
+            'test_match'     => RecognizerMatch::create([Pattern::ACTION_UP], RecognizerMatch::ANCHOR_START, false, ['gadgetId1', 'gadgetId2'], [$pattern]),
             'test_deviation' => RecognizerDeviation::create('test_match'),
             'test_progress'  => RecognizerProgress::create('test_match', 5),
         ];
@@ -34,6 +34,14 @@ class GameEngineTest extends TestCase
         $this->assertSame(5000, $startInputHandlerDirective->timeout);
         $this->assertSame('match', $startInputHandlerDirective->recognizers['test_match']->type);
         $this->assertSame(Event::REPORTS_HISTORY, $startInputHandlerDirective->events['test_match']->reports);
+    }
+
+    public function testPattern()
+    {
+        $pattern = Pattern::create(Pattern::ACTION_UP, ['gadgetId1', 'gadgetId2'], ['blue']);
+        $this->assertJsonStringEqualsJsonString('{"gadgetIds":["gadgetId1","gadgetId2"],"colors":["blue"],"action":"up","repeat":null}', json_encode($pattern));
+        $pattern = Pattern::create(Pattern::ACTION_UP, null, null, 10);
+        $this->assertJsonStringEqualsJsonString('{"gadgetIds":null,"colors":null,"action":"up","repeat":10}', json_encode($pattern));
     }
 
     public function testStopInputHandlerDirective()


### PR DESCRIPTION
The **RecognizerMatch** of the game engine did not work as expexted: Empty arrays produce another outcome with Alexa as when you omit them (`null` instead of `[]`). The **RecognizerMatch** did not work at all.

This is why I also changed the API: The required value `pattern` should be the first in the `create` method.