### PR TITLE
Fix for Gadget Controller directives

### DIFF
--- a/src/Request/Request/GameEngine/Event/Event.php
+++ b/src/Request/Request/GameEngine/Event/Event.php
@@ -19,8 +19,8 @@ class Event
 
     /**
      * @param array $amazonRequest
-     *
      * @return Event
+     * @throws \Exception
      */
     public static function fromAmazonRequest(array $amazonRequest): self
     {

--- a/src/Request/Request/GameEngine/Event/Event.php
+++ b/src/Request/Request/GameEngine/Event/Event.php
@@ -19,8 +19,10 @@ class Event
 
     /**
      * @param array $amazonRequest
-     * @return Event
+     *
      * @throws \Exception
+     *
+     * @return Event
      */
     public static function fromAmazonRequest(array $amazonRequest): self
     {

--- a/src/Request/Request/GameEngine/InputHandlerEvent.php
+++ b/src/Request/Request/GameEngine/InputHandlerEvent.php
@@ -19,7 +19,7 @@ class InputHandlerEvent extends StandardRequest
     public $originatingRequestId;
 
     /**
-     * @var Event
+     * @var Event[]
      */
     public $events = [];
 

--- a/src/Response/Directives/GadgetController/Animation.php
+++ b/src/Response/Directives/GadgetController/Animation.php
@@ -5,7 +5,7 @@ namespace MaxBeckers\AmazonAlexa\Response\Directives\GadgetController;
 /**
  * @author Maximilian Beckers <beckers.maximilian@gmail.com>
  */
-class Animations
+class Animation
 {
     /**
      * @var int|null
@@ -27,9 +27,9 @@ class Animations
      * @param array      $targetLights
      * @param Sequence[] $sequence
      *
-     * @return Animations
+     * @return Animation
      */
-    public static function create(int $repeat, array $targetLights = ['1'], array $sequence = []): self
+    public static function create(array $sequence, int $repeat=1, array $targetLights = ['1']): self
     {
         $animations = new self();
 

--- a/src/Response/Directives/GadgetController/Animations.php
+++ b/src/Response/Directives/GadgetController/Animations.php
@@ -15,7 +15,7 @@ class Animations
     /**
      * @var array
      */
-    public $targetLights = [];
+    public $targetLights = ['1'];
 
     /**
      * @var Sequence[]
@@ -29,7 +29,7 @@ class Animations
      *
      * @return Animations
      */
-    public static function create(int $repeat, array $targetLights = [], array $sequence = []): self
+    public static function create(int $repeat, array $targetLights = ['1'], array $sequence = []): self
     {
         $animations = new self();
 

--- a/src/Response/Directives/GadgetController/Parameters.php
+++ b/src/Response/Directives/GadgetController/Parameters.php
@@ -22,18 +22,18 @@ class Parameters
     public $triggerEventTimeMs;
 
     /**
-     * @var Animations|null
+     * @var Animation[]
      */
     public $animations;
 
     /**
-     * @param string          $triggerEvent
-     * @param int             $triggerEventTimeMs
-     * @param Animations|null $animations
+     * @param string      $triggerEvent
+     * @param int         $triggerEventTimeMs
+     * @param Animation[] $animations
      *
      * @return Parameters
      */
-    public static function create(string $triggerEvent = self::TRIGGER_EVENT_NONE, int $triggerEventTimeMs = 0, Animations $animations = null): self
+    public static function create(array $animations, string $triggerEvent = self::TRIGGER_EVENT_NONE, int $triggerEventTimeMs = 0): self
     {
         $parameters = new self();
 

--- a/test/Test/Response/Directives/GadgetControllerTest.php
+++ b/test/Test/Response/Directives/GadgetControllerTest.php
@@ -2,7 +2,7 @@
 
 namespace MaxBeckers\AmazonAlexa\Test\Response\Directives;
 
-use MaxBeckers\AmazonAlexa\Response\Directives\GadgetController\Animations;
+use MaxBeckers\AmazonAlexa\Response\Directives\GadgetController\Animation;
 use MaxBeckers\AmazonAlexa\Response\Directives\GadgetController\Parameters;
 use MaxBeckers\AmazonAlexa\Response\Directives\GadgetController\Sequence;
 use MaxBeckers\AmazonAlexa\Response\Directives\GadgetController\SetLightDirective;
@@ -16,12 +16,12 @@ class GadgetControllerTest extends TestCase
     public function testSetLightDirective()
     {
         $sequence   = Sequence::create(100, 'FF0099');
-        $animations = Animations::create(10, ['1'], [$sequence]);
-        $parameters = Parameters::create(Parameters::TRIGGER_EVENT_BUTTON_DOWN, 10, $animations);
+        $animations = Animation::create([$sequence], 10, ['1']);
+        $parameters = Parameters::create([$animations], Parameters::TRIGGER_EVENT_BUTTON_DOWN, 10);
 
         $sl = SetLightDirective::create(['gadgetId1', 'gadgetId2'], $parameters);
         $this->assertSame('GadgetController.SetLight', $sl->type);
         $this->assertSame(1, $sl->version);
-        $this->assertSame(100, $sl->parameters->animations->sequence[0]->durationMs);
+        $this->assertSame(100, $sl->parameters->animations[0]->sequence[0]->durationMs);
     }
 }


### PR DESCRIPTION
The current implementation returns 

> "Required property 'animations' must be an array"

I therefore changed the `Animation`-parameter to an array.

As this cannot be in use so far, I also changed the API and some moved properties and added useful default values.

This PR also contains some minor DocBlock fixes.