### PR TITLE
[WIP] Add Connections.Response request type and tests

### DIFF
--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -20,6 +20,7 @@ use MaxBeckers\AmazonAlexa\Request\Request\PlaybackController\PreviousCommandIss
 use MaxBeckers\AmazonAlexa\Request\Request\Standard\IntentRequest;
 use MaxBeckers\AmazonAlexa\Request\Request\Standard\LaunchRequest;
 use MaxBeckers\AmazonAlexa\Request\Request\Standard\SessionEndedRequest;
+use MaxBeckers\AmazonAlexa\Request\Request\System\ConnectionsResponseRequest;
 use MaxBeckers\AmazonAlexa\Request\Request\System\ExceptionEncounteredRequest;
 
 /**
@@ -54,6 +55,8 @@ class Request
         InputHandlerEvent::TYPE             => InputHandlerEvent::class,
         // can fulfill intent
         CanFulfillIntentRequest::TYPE       => CanFulfillIntentRequest::class,
+        // Connections Response Request
+        ConnectionsResponseRequest::TYPE    => ConnectionsResponseRequest::class,
     ];
 
     /**

--- a/src/Request/Request/System/ConnectionsResponseRequest.php
+++ b/src/Request/Request/System/ConnectionsResponseRequest.php
@@ -11,7 +11,6 @@ class ConnectionsResponseRequest extends SystemRequest
 {
     const TYPE = 'Connections.Response';
 
-
     /**
      * {@inheritdoc}
      */

--- a/src/Request/Request/System/ConnectionsResponseRequest.php
+++ b/src/Request/Request/System/ConnectionsResponseRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace MaxBeckers\AmazonAlexa\Request\Request\System;
+
+use MaxBeckers\AmazonAlexa\Request\Request\AbstractRequest;
+
+/**
+ * @author Charlie Root <charlie@chrl.ru>
+ */
+class ConnectionsResponseRequest extends SystemRequest
+{
+    const TYPE = 'Connections.Response';
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function fromAmazonRequest(array $amazonRequest): AbstractRequest
+    {
+        $request = new self();
+
+        $request->type = self::TYPE;
+
+        $request->setRequestData($amazonRequest);
+
+        return $request;
+    }
+}

--- a/test/Test/Request/ConnectionsResponseRequestTest.php
+++ b/test/Test/Request/ConnectionsResponseRequestTest.php
@@ -3,7 +3,6 @@
 namespace MaxBeckers\AmazonAlexa\Test\Request;
 
 use MaxBeckers\AmazonAlexa\Request\Request;
-use MaxBeckers\AmazonAlexa\Request\Request\Standard\SessionEndedRequest;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +13,6 @@ class ConnectionsResponseRequestTest extends TestCase
     public function testConnectionsResponseRequest()
     {
         $requestBody = file_get_contents(__DIR__.'/RequestData/connectionsResponseRequest.json');
-
 
         $request     = Request::fromAmazonRequest($requestBody, 'https://s3.amazonaws.com/echo.api/echo-api-cert.pem', 'signature');
         $this->assertInstanceOf(Request\System\ConnectionsResponseRequest::class, $request->request);

--- a/test/Test/Request/ConnectionsResponseRequestTest.php
+++ b/test/Test/Request/ConnectionsResponseRequestTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace MaxBeckers\AmazonAlexa\Test\Request;
+
+use MaxBeckers\AmazonAlexa\Request\Request;
+use MaxBeckers\AmazonAlexa\Request\Request\Standard\SessionEndedRequest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Charlie Root <charlie@chrl.ru>
+ */
+class ConnectionsResponseRequestTest extends TestCase
+{
+    public function testConnectionsResponseRequest()
+    {
+        $requestBody = file_get_contents(__DIR__.'/RequestData/connectionsResponseRequest.json');
+
+
+        $request     = Request::fromAmazonRequest($requestBody, 'https://s3.amazonaws.com/echo.api/echo-api-cert.pem', 'signature');
+        $this->assertInstanceOf(Request\System\ConnectionsResponseRequest::class, $request->request);
+    }
+}

--- a/test/Test/Request/RequestData/connectionsResponseRequest.json
+++ b/test/Test/Request/RequestData/connectionsResponseRequest.json
@@ -1,0 +1,55 @@
+{
+  "version": "1.0",
+  "session": {
+    "new": false,
+    "sessionId": "amzn1.echo-api.session.0000000-0000-0000-0000-00000000000",
+    "application": {
+      "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+    },
+    "attributes": {
+      "supportedHoroscopePeriods": {
+        "daily": true,
+        "weekly": false,
+        "monthly": false
+      }
+    },
+    "user": {
+      "userId": "amzn1.account.AM3B00000000000000000000000"
+    }
+  },
+  "context": {
+    "System": {
+      "application": {
+        "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+      },
+      "user": {
+        "userId": "amzn1.account.AM3B00000000000000000000000"
+      },
+      "device": {
+        "supportedInterfaces": {
+          "AudioPlayer": {}
+        }
+      }
+    },
+    "AudioPlayer": {
+      "offsetInMilliseconds": 0,
+      "playerActivity": "IDLE"
+    }
+  },
+  "request": {
+    "type": "Connections.Response",
+    "requestId": "amzn1.echo-api.request.0000000-0000-0000-0000-00000000000",
+    "timestamp": "2015-05-13T12:34:56Z",
+    "locale": "string",
+    "status": {
+      "code": "200",
+      "message": "OK"
+    },
+    "name": "Upsell",
+    "payload": {
+      "purchaseResult": "ACCEPTED",
+      "productId": "amzn1.adg.product.01321b13-7bcf-4e1b-81cb-31658fd009bb"
+    },
+    "token": "apple_pie"
+  }
+}


### PR DESCRIPTION
In this PR I wanted to add "Connections.Response" request type, that alexa sends during ISP workflow. Without that request validation fails.