### PR TITLE
Adding support for Dynamic Entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ composer.phar
 /vendor/
 composer.lock
 .php_cs.cache
+/.idea/
+.phpunit.result.cache

--- a/src/Response/Directives/Dialog/Entity/Type.php
+++ b/src/Response/Directives/Dialog/Entity/Type.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace MaxBeckers\AmazonAlexa\Response\Directives\Dialog\Entity;
+
+class Type
+{
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var TypeValue[]
+     */
+    public $values;
+
+    /**
+     * @param string      $name
+     * @param TypeValue[] $values
+     *
+     * @return Type
+     */
+    public static function create(string $name, array $values): self
+    {
+        $type = new self();
+
+        $type->name   = $name;
+        $type->values = $values;
+
+        return $type;
+    }
+}

--- a/src/Response/Directives/Dialog/Entity/TypeValue.php
+++ b/src/Response/Directives/Dialog/Entity/TypeValue.php
@@ -38,14 +38,7 @@ class TypeValue implements \JsonSerializable
     }
 
     /**
-     * Specify data which should be serialized to JSON.
-     *
-     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
-     *
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     *               which is a value of any type other than a resource
-     *
-     * @since 5.4.0
+     * {@inheritdoc}
      */
     public function jsonSerialize()
     {

--- a/src/Response/Directives/Dialog/Entity/TypeValue.php
+++ b/src/Response/Directives/Dialog/Entity/TypeValue.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace MaxBeckers\AmazonAlexa\Response\Directives\Dialog\Entity;
+
+class TypeValue implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    public $id;
+
+    /**
+     * @var string
+     */
+    public $value;
+
+    /**
+     * @var array
+     */
+    public $synonyms;
+
+    /**
+     * @param string $id
+     * @param string $value
+     * @param array  $synonyms
+     *
+     * @return TypeValue
+     */
+    public static function create(string $id, string $value, array $synonyms = []): self
+    {
+        $typeValue = new self();
+
+        $typeValue->id       = $id;
+        $typeValue->value    = $value;
+        $typeValue->synonyms = $synonyms;
+
+        return $typeValue;
+    }
+
+    /**
+     * Specify data which should be serialized to JSON.
+     *
+     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
+     *
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     *               which is a value of any type other than a resource
+     *
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id'   => $this->id,
+            'name' => [
+                'value'    => $this->value,
+                'synonyms' => $this->synonyms,
+            ],
+        ];
+    }
+}

--- a/src/Response/Directives/Dialog/UpdateDynamicEntities/Clear.php
+++ b/src/Response/Directives/Dialog/UpdateDynamicEntities/Clear.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace MaxBeckers\AmazonAlexa\Response\Directives\Dialog\UpdateDynamicEntities;
+
+class Clear extends UpdateDynamicEntities
+{
+    const UPDATE_BEHAVIOR = 'CLEAR';
+
+    /**
+     * @return Clear
+     */
+    public static function create(): self
+    {
+        $directive = new static();
+
+        $directive->type           = static::TYPE;
+        $directive->updateBehavior = static::UPDATE_BEHAVIOR;
+
+        return $directive;
+    }
+}

--- a/src/Response/Directives/Dialog/UpdateDynamicEntities/Replace.php
+++ b/src/Response/Directives/Dialog/UpdateDynamicEntities/Replace.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace MaxBeckers\AmazonAlexa\Response\Directives\Dialog\UpdateDynamicEntities;
+
+use MaxBeckers\AmazonAlexa\Response\Directives\Dialog\Entity\Type;
+
+class Replace extends UpdateDynamicEntities
+{
+    const UPDATE_BEHAVIOR = 'REPLACE';
+
+    /**
+     * @var array | null
+     */
+    public $types;
+
+    /**
+     * @param Type $type
+     */
+    public function addType(Type $type)
+    {
+        $this->types[] = $type;
+    }
+
+    /**
+     * @return Replace
+     */
+    public static function create(): self
+    {
+        $directive = new static();
+
+        $directive->type           = self::TYPE;
+        $directive->types          = [];
+        $directive->updateBehavior = static::UPDATE_BEHAVIOR;
+
+        return $directive;
+    }
+}

--- a/src/Response/Directives/Dialog/UpdateDynamicEntities/UpdateDynamicEntities.php
+++ b/src/Response/Directives/Dialog/UpdateDynamicEntities/UpdateDynamicEntities.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MaxBeckers\AmazonAlexa\Response\Directives\Dialog\UpdateDynamicEntities;
+
+use MaxBeckers\AmazonAlexa\Response\Directives\Directive;
+
+abstract class UpdateDynamicEntities extends Directive
+{
+    const TYPE = 'Dialog.UpdateDynamicEntities';
+
+    /**
+     * @var string
+     */
+    public $type;
+
+    /**
+     * @var string
+     */
+    public $updateBehavior;
+}

--- a/test/Test/Response/Data/directive_dialog_update_dynamic_entities_replace.json
+++ b/test/Test/Response/Data/directive_dialog_update_dynamic_entities_replace.json
@@ -1,0 +1,20 @@
+{
+  "type":"Dialog.UpdateDynamicEntities",
+  "updateBehavior":"REPLACE",
+  "types":[
+    {
+      "name":"AirportSlotType",
+      "values":[
+        {
+          "id":"LGA",
+          "name":{
+            "value":"LaGuardia Airport",
+            "synonyms":[
+              "New York"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/Test/Response/Data/directive_entity_type.json
+++ b/test/Test/Response/Data/directive_entity_type.json
@@ -1,0 +1,23 @@
+{
+  "name":"AirportSlotType",
+  "values":[
+    {
+      "id":"BOS",
+      "name":{
+        "value":"Logan International Airport",
+        "synonyms":[
+          "Boston Logan"
+        ]
+      }
+    },
+    {
+      "id":"LGA",
+      "name":{
+        "value":"LaGuardia Airport",
+        "synonyms":[
+          "New York"
+        ]
+      }
+    }
+  ]
+}

--- a/test/Test/Response/Data/directive_entity_type_value.json
+++ b/test/Test/Response/Data/directive_entity_type_value.json
@@ -1,0 +1,9 @@
+{
+  "id":"BOS",
+  "name":{
+    "value":"Logan International Airport",
+    "synonyms":[
+      "Boston Logan"
+    ]
+  }
+}

--- a/test/Test/Response/Directives/Dialog/Entity/TypeTest.php
+++ b/test/Test/Response/Directives/Dialog/Entity/TypeTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace MaxBeckers\AmazonAlexa\Test\Response\Directives\Dialog\Entity;
+
+use MaxBeckers\AmazonAlexa\Response\Directives\Dialog\Entity\Type;
+use MaxBeckers\AmazonAlexa\Response\Directives\Dialog\Entity\TypeValue;
+use PHPUnit\Framework\TestCase;
+
+class TypeTest extends TestCase
+{
+    public function testCreate()
+    {
+        $type = Type::create('AirportSlotType', [
+            TypeValue::create('BOS', 'Logan International Airport', ['Boston Logan']),
+            TypeValue::create('LGA', 'LaGuardia Airport', ['New York']),
+        ]);
+
+        $json     = \file_get_contents(__DIR__.'/../../../../Response/Data/directive_entity_type.json');
+        $expected = \json_encode(\json_decode($json));
+        $actual   = \json_encode($type);
+
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/test/Test/Response/Directives/Dialog/Entity/TypeValueTest.php
+++ b/test/Test/Response/Directives/Dialog/Entity/TypeValueTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MaxBeckers\AmazonAlexa\Test\Response\Directives\Dialog\Entity;
+
+use MaxBeckers\AmazonAlexa\Response\Directives\Dialog\Entity\TypeValue;
+use PHPUnit\Framework\TestCase;
+
+class TypeValueTest extends TestCase
+{
+    public function testCreate()
+    {
+        $typeValue = TypeValue::create('BOS', 'Logan International Airport', ['Boston Logan']);
+
+        $json     = \file_get_contents(__DIR__.'/../../../../Response/Data/directive_entity_type_value.json');
+        $expected = \json_encode(\json_decode($json));
+        $actual   = \json_encode($typeValue);
+
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/test/Test/Response/Directives/Dialog/UpdateDynamicEntities/ClearTest.php
+++ b/test/Test/Response/Directives/Dialog/UpdateDynamicEntities/ClearTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace MaxBeckers\AmazonAlexa\Test\Response\Directives\Dialog\UpdateDynamicEntities;
+
+use MaxBeckers\AmazonAlexa\Response\Directives\Dialog\UpdateDynamicEntities\Clear;
+use PHPUnit\Framework\TestCase;
+
+class ClearTest extends TestCase
+{
+    public function testCreate()
+    {
+        /** @var Clear $directive */
+        $directive = Clear::create();
+        $this->assertSame('Dialog.UpdateDynamicEntities', $directive->type);
+        $this->assertSame('CLEAR', $directive->updateBehavior);
+    }
+}

--- a/test/Test/Response/Directives/Dialog/UpdateDynamicEntities/ReplaceTest.php
+++ b/test/Test/Response/Directives/Dialog/UpdateDynamicEntities/ReplaceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace MaxBeckers\AmazonAlexa\Test\Response\Directives\Dialog\UpdateDynamicEntities;
+
+use MaxBeckers\AmazonAlexa\Response\Directives\Dialog\Entity\Type;
+use MaxBeckers\AmazonAlexa\Response\Directives\Dialog\Entity\TypeValue;
+use MaxBeckers\AmazonAlexa\Response\Directives\Dialog\UpdateDynamicEntities\Replace;
+use PHPUnit\Framework\TestCase;
+
+class ReplaceTest extends TestCase
+{
+    public function testCreateWithReplaceBehaviour()
+    {
+        $type = Type::create('AirportSlotType', [
+            TypeValue::create('LGA', 'LaGuardia Airport', ['New York']),
+        ]);
+
+        /** @var Replace $directive */
+        $directive = Replace::create();
+        $directive->addType($type);
+        $this->assertInternalType('array', $directive->types);
+        $this->assertSame([$type], $directive->types);
+        $this->assertSame('Dialog.UpdateDynamicEntities', $directive->type);
+        $this->assertSame('REPLACE', $directive->updateBehavior);
+
+        $json     = \file_get_contents(__DIR__.'/../../../../Response/Data/directive_dialog_update_dynamic_entities_replace.json');
+        $expected = \json_decode($json);
+
+        $this->assertSame($expected->type, $directive->type);
+        $this->assertSame($expected->updateBehavior, $directive->updateBehavior);
+        $this->assertSame(\count($expected->types), \count($directive->types));
+        $this->assertSame(\json_encode($expected->types), \json_encode($directive->types));
+    }
+}


### PR DESCRIPTION
Reference url: https://developer.amazon.com/en-US/docs/alexa/custom-skills/use-dynamic-entities-for-customized-interactions.html